### PR TITLE
Feature/timer and rebase

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ There weren't many solutions on the Play Store and the ones I found were either 
     - **Manual:** Hand-pick individual photos; they're safely copied into the app's private storage so they're always available.
 - **Smart Shuffle:** Every image is shown exactly once before the collection reshuffles in order to never getting any individual wallpaper too often.
 - **Flexible Cropping:** Choose how images fit your screen per collection: center, left-aligned, right-aligned, or fit-to-screen.
+- **Rotation Timer Modes:** Configure each collection to rotate on every lock, every 1 hour, or once per day.
 - **Quick Settings Tile:** Start, stop, or check status right from the notification shade letting you control it while doing something else.
 - **Default Wallpaper Fallback:** Pick a fallback lock screen image that's automatically restored when the service stops or pauses.
 - **Survives Reboots:** If the service was running before a restart, it picks right back up.

--- a/app/src/main/java/com/ninecsdev/wallpaperchanger/data/WallpaperRepository.kt
+++ b/app/src/main/java/com/ninecsdev/wallpaperchanger/data/WallpaperRepository.kt
@@ -13,6 +13,7 @@ import com.ninecsdev.wallpaperchanger.logic.BufferManager
 import com.ninecsdev.wallpaperchanger.logic.ImageInternalizer
 import com.ninecsdev.wallpaperchanger.model.CollectionType
 import com.ninecsdev.wallpaperchanger.model.CropRule
+import com.ninecsdev.wallpaperchanger.model.RotationFrequency
 import com.ninecsdev.wallpaperchanger.model.ServiceState
 import com.ninecsdev.wallpaperchanger.model.WallpaperCollection
 import com.ninecsdev.wallpaperchanger.model.WallpaperImage
@@ -162,8 +163,24 @@ object WallpaperRepository {
         return dao.getImageCountOfCollection(collectionId)
     }
 
-    suspend fun updateCollection(id: Long, newName: String, newRule: CropRule) {
-        dao.updateCollection(id, newName, newRule)
+    suspend fun updateCollection(
+        id: Long,
+        newName: String,
+        newRule: CropRule,
+        newFrequency: RotationFrequency
+    ) {
+        withContext(Dispatchers.IO) {
+            dao.updateCollection(id, newName, newRule, newFrequency)
+            if (dao.getActiveCollection()?.id == id) {
+                refillDiskBuffer()
+            }
+        }
+    }
+
+    suspend fun markWallpaperChanged(collectionId: Long) {
+        withContext(Dispatchers.IO) {
+            dao.updateLastWallpaperChangeAt(collectionId)
+        }
     }
 
     suspend fun deleteCollection(collection: WallpaperCollection) {

--- a/app/src/main/java/com/ninecsdev/wallpaperchanger/data/local/AppDatabase.kt
+++ b/app/src/main/java/com/ninecsdev/wallpaperchanger/data/local/AppDatabase.kt
@@ -5,6 +5,8 @@ import androidx.room.Database
 import androidx.room.Room
 import androidx.room.RoomDatabase
 import androidx.room.TypeConverters
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
 import com.ninecsdev.wallpaperchanger.model.WallpaperCollection
 import com.ninecsdev.wallpaperchanger.model.WallpaperImage
 
@@ -15,7 +17,7 @@ import com.ninecsdev.wallpaperchanger.model.WallpaperImage
 @Database(entities = [
     WallpaperCollection::class,
     WallpaperImage::class],
-    version = 1,
+    version = 2,
     // When changing the schema, increment the version number
     // and add: autoMigrations = [AutoMigration(from = 1, to = 2)]
     exportSchema = true
@@ -36,9 +38,22 @@ abstract class AppDatabase : RoomDatabase() {
                     context.applicationContext,
                     AppDatabase::class.java,
                     DB_NAME
-                ).build()
+                )
+                    .addMigrations(MIGRATION_1_2)
+                    .build()
                 INSTANCE = instance
                 instance
+            }
+        }
+
+        private val MIGRATION_1_2 = object : Migration(1, 2) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                database.execSQL(
+                    "ALTER TABLE collections ADD COLUMN rotationFrequency TEXT NOT NULL DEFAULT 'PER_LOCK'"
+                )
+                database.execSQL(
+                    "ALTER TABLE collections ADD COLUMN lastWallpaperChangeAt INTEGER NOT NULL DEFAULT 0"
+                )
             }
         }
     }

--- a/app/src/main/java/com/ninecsdev/wallpaperchanger/data/local/Converters.kt
+++ b/app/src/main/java/com/ninecsdev/wallpaperchanger/data/local/Converters.kt
@@ -5,6 +5,7 @@ import android.util.Log
 import androidx.room.TypeConverter
 import com.ninecsdev.wallpaperchanger.model.CollectionType
 import com.ninecsdev.wallpaperchanger.model.CropRule
+import com.ninecsdev.wallpaperchanger.model.RotationFrequency
 
 /**
  * Type converters for Room Database.
@@ -42,5 +43,18 @@ class Converters {
         } catch (e: IllegalArgumentException) {
             Log.e("Converters", "Invalid CropRule: $value", e)
             CropRule.CENTER
+        }
+
+    // RotationFrequency Converters
+    @TypeConverter
+    fun fromRotationFrequency(frequency: RotationFrequency): String = frequency.name
+
+    @TypeConverter
+    fun toRotationFrequency(value: String): RotationFrequency =
+        try {
+            RotationFrequency.valueOf(value)
+        } catch (e: IllegalArgumentException) {
+            Log.e("Converters", "Invalid RotationFrequency: $value", e)
+            RotationFrequency.PER_LOCK
         }
 }

--- a/app/src/main/java/com/ninecsdev/wallpaperchanger/data/local/WallpaperDao.kt
+++ b/app/src/main/java/com/ninecsdev/wallpaperchanger/data/local/WallpaperDao.kt
@@ -7,6 +7,7 @@ import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import androidx.room.Transaction
 import com.ninecsdev.wallpaperchanger.model.CropRule
+import com.ninecsdev.wallpaperchanger.model.RotationFrequency
 import com.ninecsdev.wallpaperchanger.model.WallpaperCollection
 import com.ninecsdev.wallpaperchanger.model.WallpaperImage
 import kotlinx.coroutines.flow.Flow
@@ -34,8 +35,13 @@ interface WallpaperDao {
     /**
      * Updates the name and default crop rule of a collection.
      */
-    @Query("UPDATE collections SET name = :newName, defaultCropRule = :newRule WHERE id = :collectionId")
-    suspend fun updateCollection(collectionId: Long, newName: String, newRule: CropRule)
+    @Query("UPDATE collections SET name = :newName, defaultCropRule = :newRule, rotationFrequency = :newFrequency WHERE id = :collectionId")
+    suspend fun updateCollection(
+        collectionId: Long,
+        newName: String,
+        newRule: CropRule,
+        newFrequency: RotationFrequency
+    )
 
     @Query("SELECT * FROM collections WHERE isActive = 1 LIMIT 1")
     suspend fun getActiveCollection(): WallpaperCollection?
@@ -58,6 +64,9 @@ interface WallpaperDao {
 
     @Query("UPDATE collections SET lastUsedAt = :timestamp WHERE id = :collectionId")
     suspend fun updateLastUsed(collectionId: Long, timestamp: Long = System.currentTimeMillis())
+
+    @Query("UPDATE collections SET lastWallpaperChangeAt = :timestamp WHERE id = :collectionId")
+    suspend fun updateLastWallpaperChangeAt(collectionId: Long, timestamp: Long = System.currentTimeMillis())
 
     // Wallpaper/Image Operations
     /**

--- a/app/src/main/java/com/ninecsdev/wallpaperchanger/model/WallpaperCollection.kt
+++ b/app/src/main/java/com/ninecsdev/wallpaperchanger/model/WallpaperCollection.kt
@@ -3,6 +3,9 @@ package com.ninecsdev.wallpaperchanger.model
 import android.net.Uri
 import androidx.room.Entity
 import androidx.room.PrimaryKey
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
 
 /**
  * Represents a logical list of wallpapers created by the user.
@@ -19,6 +22,8 @@ data class WallpaperCollection(
     val isActive: Boolean = false,
     val rootUri: Uri? = null,
     val defaultCropRule: CropRule = CropRule.CENTER,
+    val rotationFrequency: RotationFrequency = RotationFrequency.PER_LOCK,
+    val lastWallpaperChangeAt: Long = 0L,
     val createdAt: Long = System.currentTimeMillis(),
     val lastUsedAt: Long = System.currentTimeMillis()
 )
@@ -31,4 +36,30 @@ enum class CollectionType {
     FOLDER,
     /** Images are individually selected by the user. */
     MANUAL
+}
+
+enum class RotationFrequency {
+    PER_LOCK,
+    HOURLY,
+    PER_DAY
+}
+
+fun WallpaperCollection.shouldRotateAt(
+    nowMillis: Long = System.currentTimeMillis(),
+    zoneId: ZoneId = ZoneId.systemDefault()
+): Boolean {
+    return when (rotationFrequency) {
+        RotationFrequency.PER_LOCK -> true
+        RotationFrequency.HOURLY -> {
+            if (lastWallpaperChangeAt <= 0L) return true
+            nowMillis - lastWallpaperChangeAt >= 60L * 60L * 1000L
+        }
+        RotationFrequency.PER_DAY -> {
+            if (lastWallpaperChangeAt <= 0L) return true
+
+            val lastChangeDate = Instant.ofEpochMilli(lastWallpaperChangeAt).atZone(zoneId).toLocalDate()
+            val nowDate = Instant.ofEpochMilli(nowMillis).atZone(zoneId).toLocalDate()
+            nowDate.isAfter(lastChangeDate)
+        }
+    }
 }

--- a/app/src/main/java/com/ninecsdev/wallpaperchanger/service/ScreenOffReceiver.kt
+++ b/app/src/main/java/com/ninecsdev/wallpaperchanger/service/ScreenOffReceiver.kt
@@ -8,6 +8,8 @@ import android.os.PowerManager
 import android.util.Log
 import com.ninecsdev.wallpaperchanger.data.WallpaperRepository
 import com.ninecsdev.wallpaperchanger.logic.BufferManager
+import com.ninecsdev.wallpaperchanger.model.RotationFrequency
+import com.ninecsdev.wallpaperchanger.model.shouldRotateAt
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
@@ -45,9 +47,28 @@ class ScreenOffReceiver : BroadcastReceiver() {
                     return@launch
                 }
 
+                val activeCollection = WallpaperRepository.getActiveCollectionOnce()
+                if (activeCollection == null) {
+                    Log.w(tag, "No active collection found. Skipping wallpaper change.")
+                    return@launch
+                }
+
+                if (!activeCollection.shouldRotateAt()) {
+                    val frequencyLabel = when (activeCollection.rotationFrequency) {
+                        RotationFrequency.PER_LOCK -> "per lock"
+                        RotationFrequency.HOURLY -> "hourly"
+                        RotationFrequency.PER_DAY -> "daily"
+                    }
+                    Log.d(tag, "Rotation skipped. Timer for $frequencyLabel not met yet.")
+                    return@launch
+                }
+
                 // Apply the pre-processed buffer image and prepare next image
-                applyBufferToLockScreen(context)
-                WallpaperRepository.refillDiskBuffer()
+                val applied = applyBufferToLockScreen(context)
+                if (applied) {
+                    WallpaperRepository.markWallpaperChanged(activeCollection.id)
+                    WallpaperRepository.refillDiskBuffer()
+                }
             } catch (e: Exception) {
                 Log.e(tag, "Error during wallpaper change", e)
             } finally {
@@ -62,13 +83,13 @@ class ScreenOffReceiver : BroadcastReceiver() {
      * This bypasses the Bitmap heap, preventing OutOfMemory errors
      * and instantly changes the wallpaper.
      */
-    private fun applyBufferToLockScreen(context: Context) {
+    private fun applyBufferToLockScreen(context: Context): Boolean {
         try {
             val bufferFile = BufferManager.getBufferFile()
 
             if (!bufferFile.exists()) {
                 Log.w(tag, "Buffer file missing. Is the service initialized?")
-                return
+                return false
             }
 
             bufferFile.inputStream().use { stream ->
@@ -81,9 +102,11 @@ class ScreenOffReceiver : BroadcastReceiver() {
                 )
             }
             Log.i(tag, "Wallpaper applied successfully from disk buffer.")
+            return true
 
         } catch (e: Exception) {
             Log.e(tag, "Failed to stream buffer to lock screen", e)
+            return false
         }
     }
 }

--- a/app/src/main/java/com/ninecsdev/wallpaperchanger/ui/MainActivity.kt
+++ b/app/src/main/java/com/ninecsdev/wallpaperchanger/ui/MainActivity.kt
@@ -179,11 +179,12 @@ class MainActivity : ComponentActivity() {
                                 collection = collection,
                                 isProcessing = collectionState.isProcessing,
                                 onDismiss = { collectionViewModel.closeEditModal() },
-                                onEdit = { newName, newRule ->
+                                onEdit = { newName, newRule, newFrequency ->
                                     collectionViewModel.updateCollection(
                                         collection.id,
                                         newName,
-                                        newRule
+                                        newRule,
+                                        newFrequency
                                     )
                                 },
                                 onSetActive = { mainViewModel.setActiveCollection(collection.id) },

--- a/app/src/main/java/com/ninecsdev/wallpaperchanger/ui/collectionscreen/CollectionViewModel.kt
+++ b/app/src/main/java/com/ninecsdev/wallpaperchanger/ui/collectionscreen/CollectionViewModel.kt
@@ -8,6 +8,7 @@ import com.ninecsdev.wallpaperchanger.data.WallpaperRepository
 import com.ninecsdev.wallpaperchanger.logic.ImageInternalizer
 import com.ninecsdev.wallpaperchanger.model.CollectionSortOrder
 import com.ninecsdev.wallpaperchanger.model.CropRule
+import com.ninecsdev.wallpaperchanger.model.RotationFrequency
 import com.ninecsdev.wallpaperchanger.model.WallpaperCollection
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -117,9 +118,14 @@ class CollectionViewModel(application: Application) : AndroidViewModel(applicati
         }
     }
 
-    fun updateCollection(collectionId: Long, newName: String, cropRule: CropRule) {
+    fun updateCollection(
+        collectionId: Long,
+        newName: String,
+        cropRule: CropRule,
+        rotationFrequency: RotationFrequency
+    ) {
         viewModelScope.launch {
-            repository.updateCollection(collectionId, newName, cropRule)
+            repository.updateCollection(collectionId, newName, cropRule, rotationFrequency)
         }
     }
 

--- a/app/src/main/java/com/ninecsdev/wallpaperchanger/ui/collectionscreen/EditCollectionCard.kt
+++ b/app/src/main/java/com/ninecsdev/wallpaperchanger/ui/collectionscreen/EditCollectionCard.kt
@@ -42,6 +42,7 @@ import androidx.compose.ui.window.DialogProperties
 import com.ninecsdev.wallpaperchanger.R
 import com.ninecsdev.wallpaperchanger.model.CollectionType
 import com.ninecsdev.wallpaperchanger.model.CropRule
+import com.ninecsdev.wallpaperchanger.model.RotationFrequency
 import com.ninecsdev.wallpaperchanger.model.WallpaperCollection
 import com.ninecsdev.wallpaperchanger.ui.components.CropRuleSelector
 import com.ninecsdev.wallpaperchanger.ui.components.NothingTextField
@@ -58,13 +59,14 @@ fun EditCollectionCard(
     collection: WallpaperCollection,
     isProcessing: Boolean = false,
     onDismiss: () -> Unit,
-    onEdit: (String, CropRule) -> Unit,
+    onEdit: (String, CropRule, RotationFrequency) -> Unit,
     onDelete: () -> Unit,
     onSetActive: () -> Unit,
     onSyncClick: () -> Unit
 ) {
     var nameText by remember { mutableStateOf(collection.name) }
     var selectedRule by remember { mutableStateOf(collection.defaultCropRule) }
+    var selectedRotationFrequency by remember { mutableStateOf(collection.rotationFrequency) }
 
     Dialog(
         onDismissRequest = if (isProcessing) ({}) else onDismiss,
@@ -102,6 +104,13 @@ fun EditCollectionCard(
                         onRuleSelected = { selectedRule = it }
                     )
 
+                    Spacer(modifier = Modifier.height(16.dp))
+
+                    RotationFrequencySelector(
+                        selectedFrequency = selectedRotationFrequency,
+                        onFrequencySelected = { selectedRotationFrequency = it }
+                    )
+
                     Spacer(modifier = Modifier.height(24.dp))
 
                     ManagementButtons(onDelete = onDelete)
@@ -110,9 +119,14 @@ fun EditCollectionCard(
 
                     EditCardActions(
                         isActive = collection.isActive,
-                        isChanged = nameText != collection.name || selectedRule != collection.defaultCropRule,
+                        isChanged = nameText != collection.name ||
+                            selectedRule != collection.defaultCropRule ||
+                            selectedRotationFrequency != collection.rotationFrequency,
                         onSetActive = onSetActive,
-                        onSave = { onEdit(nameText, selectedRule); onDismiss() },
+                        onSave = {
+                            onEdit(nameText, selectedRule, selectedRotationFrequency)
+                            onDismiss()
+                        },
                         onDismiss = onDismiss
                     )
                 }
@@ -125,6 +139,69 @@ fun EditCollectionCard(
                 }
             }
         }
+    }
+}
+
+@Composable
+private fun RotationFrequencySelector(
+    selectedFrequency: RotationFrequency,
+    onFrequencySelected: (RotationFrequency) -> Unit
+) {
+    Text(
+        text = "ROTATION FREQUENCY",
+        style = MaterialTheme.typography.labelSmall,
+        color = NothingWhite.copy(alpha = 0.7f),
+        letterSpacing = 1.sp,
+        fontWeight = FontWeight.Bold
+    )
+
+    Spacer(modifier = Modifier.height(8.dp))
+
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        TimerOptionButton(
+            label = "PER LOCK",
+            selected = selectedFrequency == RotationFrequency.PER_LOCK,
+            onClick = { onFrequencySelected(RotationFrequency.PER_LOCK) },
+            modifier = Modifier.weight(1f)
+        )
+        TimerOptionButton(
+            label = "EVERY 1H",
+            selected = selectedFrequency == RotationFrequency.HOURLY,
+            onClick = { onFrequencySelected(RotationFrequency.HOURLY) },
+            modifier = Modifier.weight(1f)
+        )
+        TimerOptionButton(
+            label = "DAILY",
+            selected = selectedFrequency == RotationFrequency.PER_DAY,
+            onClick = { onFrequencySelected(RotationFrequency.PER_DAY) },
+            modifier = Modifier.weight(1f)
+        )
+    }
+}
+
+@Composable
+private fun TimerOptionButton(
+    label: String,
+    selected: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    OutlinedButton(
+        onClick = onClick,
+        modifier = modifier,
+        shape = RoundedCornerShape(8.dp),
+        colors = ButtonDefaults.outlinedButtonColors(contentColor = NothingWhite),
+        border = BorderStroke(1.dp, NothingWhite.copy(alpha = if (selected) 0.8f else 0.3f))
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelSmall,
+            fontWeight = FontWeight.Bold,
+            color = NothingWhite.copy(alpha = if (selected) 1f else 0.7f)
+        )
     }
 }
 
@@ -249,7 +326,7 @@ fun EditCollectionCardPreview() {
                 type = CollectionType.FOLDER
             ),
             onDismiss = {},
-            onEdit = { _, _ -> },
+            onEdit = { _, _, _ -> },
             onDelete = {},
             onSetActive = {},
             onSyncClick = {}
@@ -269,7 +346,7 @@ fun EditCollectionCardManualPreview() {
                     type = CollectionType.MANUAL
                 ),
                 onDismiss = {},
-                onEdit = { _, _ -> },
+                onEdit = { _, _, _ -> },
                 onDelete = {},
                 onSetActive = {},
                 onSyncClick = {}
@@ -290,7 +367,7 @@ fun EditCollectionCardActivePreview() {
                 isActive = true
             ),
             onDismiss = {},
-            onEdit = { _, _ -> },
+            onEdit = { _, _, _ -> },
             onDelete = {},
             onSetActive = {},
             onSyncClick = {}
@@ -311,7 +388,7 @@ fun EditCollectionCardSyncingPreview() {
                 ),
                 isProcessing = true,
                 onDismiss = {},
-                onEdit = { _, _ -> },
+                onEdit = { _, _, _ -> },
                 onDelete = {},
                 onSetActive = {},
                 onSyncClick = {}

--- a/app/src/test/java/com/ninecsdev/wallpaperchanger/model/WallpaperCollectionRotationTest.kt
+++ b/app/src/test/java/com/ninecsdev/wallpaperchanger/model/WallpaperCollectionRotationTest.kt
@@ -1,0 +1,92 @@
+package com.ninecsdev.wallpaperchanger.model
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.time.ZoneId
+import java.time.ZonedDateTime
+
+class WallpaperCollectionRotationTest {
+
+    @Test
+    fun perLock_alwaysRotates() {
+        val collection = WallpaperCollection(
+            name = "Test",
+            type = CollectionType.MANUAL,
+            rotationFrequency = RotationFrequency.PER_LOCK,
+            lastWallpaperChangeAt = ZonedDateTime.of(2026, 3, 14, 10, 0, 0, 0, ZoneId.of("UTC"))
+                .toInstant()
+                .toEpochMilli()
+        )
+
+        val now = ZonedDateTime.of(2026, 3, 14, 10, 1, 0, 0, ZoneId.of("UTC"))
+            .toInstant()
+            .toEpochMilli()
+
+        assertTrue(collection.shouldRotateAt(now, ZoneId.of("UTC")))
+    }
+
+    @Test
+    fun perDay_doesNotRotateAgainOnSameDate() {
+        val zone = ZoneId.of("UTC")
+        val lastChanged = ZonedDateTime.of(2026, 3, 14, 0, 1, 0, 0, zone).toInstant().toEpochMilli()
+        val now = ZonedDateTime.of(2026, 3, 14, 23, 59, 0, 0, zone).toInstant().toEpochMilli()
+
+        val collection = WallpaperCollection(
+            name = "Daily",
+            type = CollectionType.MANUAL,
+            rotationFrequency = RotationFrequency.PER_DAY,
+            lastWallpaperChangeAt = lastChanged
+        )
+
+        assertFalse(collection.shouldRotateAt(now, zone))
+    }
+
+    @Test
+    fun hourly_doesNotRotateBeforeOneHour() {
+        val zone = ZoneId.of("UTC")
+        val lastChanged = ZonedDateTime.of(2026, 3, 14, 10, 0, 0, 0, zone).toInstant().toEpochMilli()
+        val now = ZonedDateTime.of(2026, 3, 14, 10, 59, 59, 0, zone).toInstant().toEpochMilli()
+
+        val collection = WallpaperCollection(
+            name = "Hourly",
+            type = CollectionType.MANUAL,
+            rotationFrequency = RotationFrequency.HOURLY,
+            lastWallpaperChangeAt = lastChanged
+        )
+
+        assertFalse(collection.shouldRotateAt(now, zone))
+    }
+
+    @Test
+    fun hourly_rotatesAfterOneHour() {
+        val zone = ZoneId.of("UTC")
+        val lastChanged = ZonedDateTime.of(2026, 3, 14, 10, 0, 0, 0, zone).toInstant().toEpochMilli()
+        val now = ZonedDateTime.of(2026, 3, 14, 11, 0, 0, 0, zone).toInstant().toEpochMilli()
+
+        val collection = WallpaperCollection(
+            name = "Hourly",
+            type = CollectionType.MANUAL,
+            rotationFrequency = RotationFrequency.HOURLY,
+            lastWallpaperChangeAt = lastChanged
+        )
+
+        assertTrue(collection.shouldRotateAt(now, zone))
+    }
+
+    @Test
+    fun perDay_rotatesOnNextDate() {
+        val zone = ZoneId.of("UTC")
+        val lastChanged = ZonedDateTime.of(2026, 3, 14, 23, 59, 0, 0, zone).toInstant().toEpochMilli()
+        val now = ZonedDateTime.of(2026, 3, 15, 0, 0, 1, 0, zone).toInstant().toEpochMilli()
+
+        val collection = WallpaperCollection(
+            name = "Daily",
+            type = CollectionType.MANUAL,
+            rotationFrequency = RotationFrequency.PER_DAY,
+            lastWallpaperChangeAt = lastChanged
+        )
+
+        assertTrue(collection.shouldRotateAt(now, zone))
+    }
+}


### PR DESCRIPTION
This pull request introduces a new feature allowing users to configure how often wallpapers rotate for each collection (per lock, hourly, or daily). It updates the data model, persistence layer, and user interface to support this, and ensures the rotation logic is respected when changing wallpapers. Additionally, it includes a database migration to preserve user data.

**Feature: Configurable Wallpaper Rotation Frequency**

- Added `rotationFrequency` and `lastWallpaperChangeAt` fields to the `WallpaperCollection` data class, and introduced the `RotationFrequency` enum to represent rotation modes (per lock, hourly, daily). Also added a helper function `shouldRotateAt()` to determine if a collection should rotate based on its frequency and last change time. [[1]](diffhunk://#diff-8656231079f8334109dc27b518e6a2f319bd208dee22b6586f81cef372639e71R25-R26) [[2]](diffhunk://#diff-8656231079f8334109dc27b518e6a2f319bd208dee22b6586f81cef372639e71R40-R65)
- Updated the Room database schema to include the new fields, provided a migration from version 1 to 2, and added type converters for the new enum. [[1]](diffhunk://#diff-0e6a8aa87f3bb52d45f1a0f75b304308b570fc634f1beae3363aa8ec6babdab0L18-R20) [[2]](diffhunk://#diff-0e6a8aa87f3bb52d45f1a0f75b304308b570fc634f1beae3363aa8ec6babdab0L39-R58) [[3]](diffhunk://#diff-c644128bd0dead682e240d0293ae52209386f3b1fe7453aaafc4b3082dc33040R8) [[4]](diffhunk://#diff-c644128bd0dead682e240d0293ae52209386f3b1fe7453aaafc4b3082dc33040R47-R59)
- Modified the DAO and repository methods to support updating and persisting the new rotation frequency and last change timestamp, including marking when a wallpaper change occurs. [[1]](diffhunk://#diff-48daac55dd2b3926c3efa68f495f7061103b1e8e7ae376f9a95b473f8a36e7dbL37-R44) [[2]](diffhunk://#diff-48daac55dd2b3926c3efa68f495f7061103b1e8e7ae376f9a95b473f8a36e7dbR68-R70) [[3]](diffhunk://#diff-2cd913e4d023f295e0c47fb654d3eac3a2df268cf2daed201b68420f52b788f8L165-R183)
- Updated the `ScreenOffReceiver` logic to check if a collection should rotate based on its configured frequency, and to update the last change timestamp only when a new wallpaper is actually applied. [[1]](diffhunk://#diff-9e8d3554d02b1ed107d42419485968c8623675181c3560ac0c62e57ad11cfb0eR11-R12) [[2]](diffhunk://#diff-9e8d3554d02b1ed107d42419485968c8623675181c3560ac0c62e57ad11cfb0eR50-R71) [[3]](diffhunk://#diff-9e8d3554d02b1ed107d42419485968c8623675181c3560ac0c62e57ad11cfb0eL65-R92) [[4]](diffhunk://#diff-9e8d3554d02b1ed107d42419485968c8623675181c3560ac0c62e57ad11cfb0eR105-R109)

**UI and User Experience**

- Extended the collection edit dialog and related ViewModel/UI logic to allow users to select the rotation frequency for each collection. The dialog now detects changes to the frequency and passes the new value through the update flow. [[1]](diffhunk://#diff-2a960aa5367c218148e601bc0d8ca61e87d4f367f49ff5901f95a02d4cd1ae76R45) [[2]](diffhunk://#diff-2a960aa5367c218148e601bc0d8ca61e87d4f367f49ff5901f95a02d4cd1ae76L61-R69) [[3]](diffhunk://#diff-2a960aa5367c218148e601bc0d8ca61e87d4f367f49ff5901f95a02d4cd1ae76R107-R113) [[4]](diffhunk://#diff-2a960aa5367c218148e601bc0d8ca61e87d4f367f49ff5901f95a02d4cd1ae76L113-R129) [[5]](diffhunk://#diff-3f353de7a126af479e7fc215bc9c173c10289aace33366e581e3db47ea3eec6eL182-R187) [[6]](diffhunk://#diff-4e3a359c2dd830f4e60028ee679ecf87e53fc7e41ba1568e2c5292a1e3199cabR11) [[7]](diffhunk://#diff-4e3a359c2dd830f4e60028ee679ecf87e53fc7e41ba1568e2c5292a1e3199cabL120-R128)
- Updated the README to document the new rotation timer modes feature.